### PR TITLE
chore(CI): parallel fleetscope_test init

### DIFF
--- a/test/integration/fleetscope/fleetscope_test.go
+++ b/test/integration/fleetscope/fleetscope_test.go
@@ -30,6 +30,7 @@ func TestFleetscope(t *testing.T) {
 	} {
 		envName := envName
 		t.Run(envName, func(t *testing.T) {
+			t.Parallel()
 			multitenant := tft.NewTFBlueprintTest(t,
 				tft.WithTFDir(fmt.Sprintf("../../../2-multitenant/envs/%s", envName)),
 			)
@@ -42,7 +43,6 @@ func TestFleetscope(t *testing.T) {
 				tft.WithTFDir(fmt.Sprintf("../../../4-fleetscope/envs/%s", envName)),
 				tft.WithVars(vars),
 			)
-			t.Parallel()
 			fleetscope.Test()
 		})
 	}


### PR DESCRIPTION
With bpt v0.13.0 `GetStringOutput{*}` should now be parallel safe: https://github.com/GoogleCloudPlatform/cloud-foundation-toolkit/blob/master/infra/blueprint-test/pkg/tft/terraform.go#L351