### PR TITLE
chore(CI): use larger collusion domain for project

### DIFF
--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -50,11 +50,12 @@ module "project" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 14.0"
 
-  name              = "ci-enterprise-application"
-  random_project_id = "true"
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                     = "ci-enterprise-application"
+  random_project_id        = "true"
+  random_project_id_length = 4
+  org_id                   = var.org_id
+  folder_id                = var.folder_id
+  billing_account          = var.billing_account
 
   activate_apis = [
     "cloudbuild.googleapis.com",


### PR DESCRIPTION
- "Sets the length of `random_project_id` to the provided length, and uses a `random_string` for a larger collusion domain. Recommended for use with CI."