### PR TITLE
feat: cross_project_sa upstream

### DIFF
--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=63c2e12076cf32ccca90f515d423ab7a615924f4"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=deab8d2023df82b508c1dce0d58358492ecb844f"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=cfc07e84716b388f9f525b9b276666e778765744"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=fb338df80d09680928b412ce9260e9f6e1ae4c60"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=dd291dac521beba4a862a3bb68a873ca2e1cfa20"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=4441b61c1d3d21bba8d5bbdf030bd224b3bb2bdf"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=fb338df80d09680928b412ce9260e9f6e1ae4c60"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=63c2e12076cf32ccca90f515d423ab7a615924f4"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=38dc8d34723c5a1def3cb14aaba15609061799f3"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=b706737f52db669d0c822da3973eb541fe58a6aa"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=94cc36869e1d7268d2abb422bc7a595d704ce1fb"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=660045720904c6148f01550ea9882e3e91810916"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -75,11 +75,8 @@ data "google_compute_subnetwork" "default" {
 
 // Create a GKE cluster in each subnetwork
 module "gke" {
-
-  // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
-  // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=deab8d2023df82b508c1dce0d58358492ecb844f"
+  source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
+  version = "~> 30.2"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=b706737f52db669d0c822da3973eb541fe58a6aa"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=cfc07e84716b388f9f525b9b276666e778765744"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"
@@ -93,7 +93,9 @@ module "gke" {
   ip_range_pods      = each.value.secondary_ip_range[0].range_name
   ip_range_services  = each.value.secondary_ip_range[1].range_name
   release_channel    = var.release_channel
-  fleet_project      = module.eab_fleet_project.project_id
+
+  fleet_project                     = module.eab_fleet_project.project_id
+  fleet_project_grant_service_agent = true
 
   monitoring_enable_managed_prometheus = true
   monitoring_enabled_components        = ["SYSTEM_COMPONENTS", "DEPLOYMENT"]

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=4441b61c1d3d21bba8d5bbdf030bd224b3bb2bdf"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=94cc36869e1d7268d2abb422bc7a595d704ce1fb"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"

--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -79,7 +79,7 @@ module "gke" {
   // TODO(apeabody) replace when beta-private-cluster ~> 30.2 released
   // source  = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
   // version = "~> 30.1"
-  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=660045720904c6148f01550ea9882e3e91810916"
+  source = "github.com/terraform-google-modules/terraform-google-kubernetes-engine//modules/beta-private-cluster?ref=38dc8d34723c5a1def3cb14aaba15609061799f3"
 
   for_each = data.google_compute_subnetwork.default
   name     = "cluster-${each.value.region}-${var.env}"


### PR DESCRIPTION
* With v30.2 the GKE module can now `fleet_project_grant_service_agent`
* `google_project_service_identity` still requires the beta provider, so we'll still need to use the beta version