### PR TITLE
fix: Grants metric and trace roles to k8s agent, enables metric api

### DIFF
--- a/2-multitenant/modules/env_baseline/main.tf
+++ b/2-multitenant/modules/env_baseline/main.tf
@@ -56,7 +56,8 @@ module "eab_cluster_project" {
     "trafficdirector.googleapis.com",
     "anthosconfigmanagement.googleapis.com",
     "sourcerepo.googleapis.com",
-    "sqladmin.googleapis.com"
+    "sqladmin.googleapis.com",
+    "cloudtrace.googleapis.com"
   ]
 }
 

--- a/4-fleetscope/modules/env_baseline/acm.tf
+++ b/4-fleetscope/modules/env_baseline/acm.tf
@@ -74,6 +74,18 @@ resource "google_gke_hub_feature_membership" "acm_feature_member" {
   ]
 }
 
+# Allow Config Sync to create trace
+resource "google_project_iam_binding" "acm_wi_trace_agent" {
+  project = var.cluster_project_id
+
+  role = "roles/cloudtrace.agent"
+  members = [
+    "serviceAccount:${var.fleet_project_id}.svc.id.goog[config-management-monitoring/default]",
+    "serviceAccount:${var.fleet_project_id}.svc.id.goog[default/bank-of-anthos]",
+    "serviceAccount:${var.fleet_project_id}.svc.id.goog[gatekeeper-system/gatekeeper-admin]",
+  ]
+}
+
 # Allow Config Sync to send metrics
 resource "google_project_iam_binding" "acm_wi_metricWriter" {
   project = var.cluster_project_id
@@ -81,5 +93,7 @@ resource "google_project_iam_binding" "acm_wi_metricWriter" {
   role = "roles/monitoring.metricWriter"
   members = [
     "serviceAccount:${var.fleet_project_id}.svc.id.goog[config-management-monitoring/default]",
+    "serviceAccount:${var.fleet_project_id}.svc.id.goog[default/bank-of-anthos]",
+    "serviceAccount:${var.fleet_project_id}.svc.id.goog[gatekeeper-system/gatekeeper-admin]",
   ]
 }

--- a/4-fleetscope/modules/env_baseline/acm.tf
+++ b/4-fleetscope/modules/env_baseline/acm.tf
@@ -74,7 +74,7 @@ resource "google_gke_hub_feature_membership" "acm_feature_member" {
   ]
 }
 
-# Allow Config Sync to create trace
+# Allow Services Accounts to create trace
 resource "google_project_iam_binding" "acm_wi_trace_agent" {
   project = var.cluster_project_id
 
@@ -86,7 +86,7 @@ resource "google_project_iam_binding" "acm_wi_trace_agent" {
   ]
 }
 
-# Allow Config Sync to send metrics
+# Allow Services Accounts to send metrics
 resource "google_project_iam_binding" "acm_wi_metricWriter" {
   project = var.cluster_project_id
 

--- a/test/integration/multitenant/multitenant_test.go
+++ b/test/integration/multitenant/multitenant_test.go
@@ -80,6 +80,7 @@ func TestMultitenant(t *testing.T) {
 							"trafficdirector.googleapis.com",
 							"anthosconfigmanagement.googleapis.com",
 							"sourcerepo.googleapis.com",
+							"cloudtrace.googleapis.com",
 						},
 					},
 				} {
@@ -136,7 +137,7 @@ func TestMultitenant(t *testing.T) {
 					workloadIdentitiesSaListMembers := utils.GetResultStrSlice(workloadIdentitiesSAPolicyOp.Get("bindings.members").Array())
 					assert.Subset(workloadIdentitiesSaListMembers, workloadIdentitiesUsers, fmt.Sprintf("service account %s should have workload identity users", workloadIdentitiesSAEmail))
 					assert.Equal(len(workloadIdentitiesUsers), len(workloadIdentitiesSaListMembers), fmt.Sprintf("service account % should have %d workload identity users", workloadIdentitiesSAEmail, len(workloadIdentitiesUsers)))
-			}
+				}
 
 				// Service Identity
 				fleetProjectNumber := gcloud.Runf(t, "projects describe %s", fleetProjectID).Get("projectNumber").String()


### PR DESCRIPTION
Enables metric API on GKE project, grants roles to missing agents