### PR TITLE
feat: add backend.tf instructions and cluster service accounts output

### DIFF
--- a/1-bootstrap/README.md
+++ b/1-bootstrap/README.md
@@ -63,6 +63,8 @@ If you receive any errors or made any changes to the Terraform config or `terraf
 
 ### Updating `backend.tf` files on the repository
 
+Within the repository, you'll find `backend.tf` files that define the GCS bucket for storing the Terraform state. By running the commands below, instances of `UPDATE_ME` placeholders in these files will be automatically replaced with the actual name of your GCS bucket.
+
 1. Running the series of commands below will update the remote state bucket for `backend.tf` files on the repository.
 
    ```bash

--- a/1-bootstrap/README.md
+++ b/1-bootstrap/README.md
@@ -61,6 +61,27 @@ You can now deploy the common environment for these pipelines.
 
 If you receive any errors or made any changes to the Terraform config or `terraform.tfvars`, re-run `terraform plan` before you run `terraform apply`.
 
+### Updating `backend.tf` files on the repository
+
+1. Running the series of commands below will update the remote state bucket for `backend.tf` files on the repository.
+
+   ```bash
+   export backend_bucket=$(terraform output -raw state_bucket)
+   echo "backend_bucket = ${backend_bucket}"
+
+   cp backend.tf.example backend.tf
+   cd ..
+
+   for i in `find . -name 'backend.tf'`; do sed -i'' -e "s/UPDATE_ME/${backend_bucket}/" $i; done
+   ```
+
+1. Re-run `terraform init`. When you're prompted, agree to copy Terraform state to Cloud Storage.
+
+   ```bash
+   cd 1-bootstrap
+
+   terraform init
+   ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs

--- a/2-multitenant/envs/development/README.md
+++ b/2-multitenant/envs/development/README.md
@@ -15,7 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
-| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
+| cluster\_service\_accounts | The default service accounts used for nodes, if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/development/README.md
+++ b/2-multitenant/envs/development/README.md
@@ -15,6 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
+| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/development/outputs.tf
+++ b/2-multitenant/envs/development/outputs.tf
@@ -58,3 +58,8 @@ output "cluster_type" {
   description = "Cluster type"
   value       = module.env.cluster_type
 }
+
+output "cluster_service_accounts" {
+  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  value       = module.env.cluster_service_accounts
+}

--- a/2-multitenant/envs/development/outputs.tf
+++ b/2-multitenant/envs/development/outputs.tf
@@ -60,6 +60,6 @@ output "cluster_type" {
 }
 
 output "cluster_service_accounts" {
-  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  description = "The default service accounts used for nodes, if not overridden in node_pools."
   value       = module.env.cluster_service_accounts
 }

--- a/2-multitenant/envs/nonproduction/README.md
+++ b/2-multitenant/envs/nonproduction/README.md
@@ -15,7 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
-| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
+| cluster\_service\_accounts | The default service accounts used for nodes, if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/nonproduction/README.md
+++ b/2-multitenant/envs/nonproduction/README.md
@@ -15,6 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
+| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/nonproduction/outputs.tf
+++ b/2-multitenant/envs/nonproduction/outputs.tf
@@ -58,3 +58,8 @@ output "cluster_type" {
   description = "Cluster type"
   value       = module.env.cluster_type
 }
+
+output "cluster_service_accounts" {
+  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  value       = module.env.cluster_service_accounts
+}

--- a/2-multitenant/envs/nonproduction/outputs.tf
+++ b/2-multitenant/envs/nonproduction/outputs.tf
@@ -60,6 +60,6 @@ output "cluster_type" {
 }
 
 output "cluster_service_accounts" {
-  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  description = "The default service accounts used for nodes, if not overridden in node_pools."
   value       = module.env.cluster_service_accounts
 }

--- a/2-multitenant/envs/production/README.md
+++ b/2-multitenant/envs/production/README.md
@@ -15,7 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
-| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
+| cluster\_service\_accounts | The default service accounts used for nodes, if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/production/README.md
+++ b/2-multitenant/envs/production/README.md
@@ -15,6 +15,7 @@
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
+| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | env | Environment |
 | fleet\_project\_id | Fleet Project ID |

--- a/2-multitenant/envs/production/outputs.tf
+++ b/2-multitenant/envs/production/outputs.tf
@@ -58,3 +58,8 @@ output "cluster_type" {
   description = "Cluster type"
   value       = module.env.cluster_type
 }
+
+output "cluster_service_accounts" {
+  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  value       = module.env.cluster_service_accounts
+}

--- a/2-multitenant/envs/production/outputs.tf
+++ b/2-multitenant/envs/production/outputs.tf
@@ -60,6 +60,6 @@ output "cluster_type" {
 }
 
 output "cluster_service_accounts" {
-  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  description = "The default service accounts used for nodes, if not overridden in node_pools."
   value       = module.env.cluster_service_accounts
 }

--- a/2-multitenant/modules/env_baseline/README.md
+++ b/2-multitenant/modules/env_baseline/README.md
@@ -36,6 +36,7 @@ The following resources are created:
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
+| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | fleet\_project\_id | Fleet Project ID |
 | network\_project\_id | Network Project ID |

--- a/2-multitenant/modules/env_baseline/README.md
+++ b/2-multitenant/modules/env_baseline/README.md
@@ -36,7 +36,7 @@ The following resources are created:
 | cluster\_membership\_ids | GKE cluster membership IDs |
 | cluster\_project\_id | Cluster Project ID |
 | cluster\_regions | Regions with clusters |
-| cluster\_service\_accounts | The service accounts to default running nodes as if not overridden in node\_pools. |
+| cluster\_service\_accounts | The default service accounts used for nodes, if not overridden in node\_pools. |
 | cluster\_type | Cluster type |
 | fleet\_project\_id | Fleet Project ID |
 | network\_project\_id | Network Project ID |

--- a/2-multitenant/modules/env_baseline/outputs.tf
+++ b/2-multitenant/modules/env_baseline/outputs.tf
@@ -66,7 +66,7 @@ output "cluster_type" {
 }
 
 output "cluster_service_accounts" {
-  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  description = "The default service accounts used for nodes, if not overridden in node_pools."
   value = [
     for value in merge(module.gke-standard, module.gke-autopilot) : value.service_account
   ]

--- a/2-multitenant/modules/env_baseline/outputs.tf
+++ b/2-multitenant/modules/env_baseline/outputs.tf
@@ -64,3 +64,10 @@ output "cluster_type" {
   description = "Cluster type"
   value       = var.cluster_type
 }
+
+output "cluster_service_accounts" {
+  description = "The service accounts to default running nodes as if not overridden in node_pools."
+  value = [
+    for value in merge(module.gke-standard, module.gke-autopilot) : value.service_account
+  ]
+}

--- a/test/integration/multitenant/multitenant_test.go
+++ b/test/integration/multitenant/multitenant_test.go
@@ -199,6 +199,15 @@ func TestMultitenant(t *testing.T) {
 					})
 				}
 
+				cluster_service_accounts := multitenant.GetJsonOutput("cluster_service_accounts").Array()
+
+				assert.True((len(cluster_service_accounts) > 0), "The terraform output must contain more than 0 service accounts.")
+				// create regex to validate service accounts emails
+				saRegex := `^[a-zA-Z0-9_+-]+@[a-zA-Z0-9-].iam.gserviceaccount.com$`
+				re := regexp.MustCompile(saRegex)
+				for _, sa := range cluster_service_accounts {
+					assert.True(re.MatchString(sa.String()), "The cluster SA value must be a Google Service Account")
+				}
 			})
 
 			multitenant.Test()

--- a/test/integration/multitenant/multitenant_test.go
+++ b/test/integration/multitenant/multitenant_test.go
@@ -201,12 +201,11 @@ func TestMultitenant(t *testing.T) {
 
 				cluster_service_accounts := multitenant.GetJsonOutput("cluster_service_accounts").Array()
 
-				assert.True((len(cluster_service_accounts) > 0), "The terraform output must contain more than 0 service accounts.")
+				assert.Greater(len(cluster_service_accounts), 0, "The terraform output must contain more than 0 service accounts.")
 				// create regex to validate service accounts emails
 				saRegex := `^[a-zA-Z0-9_+-]+@[a-zA-Z0-9-]+.iam.gserviceaccount.com$`
-				re := regexp.MustCompile(saRegex)
 				for _, sa := range cluster_service_accounts {
-					assert.True(re.MatchString(sa.String()), "The cluster SA value must be a Google Service Account")
+					assert.Regexp(saRegex, sa.String(), "The cluster SA value must be a Google Service Account")
 				}
 			})
 

--- a/test/integration/multitenant/multitenant_test.go
+++ b/test/integration/multitenant/multitenant_test.go
@@ -203,7 +203,7 @@ func TestMultitenant(t *testing.T) {
 
 				assert.True((len(cluster_service_accounts) > 0), "The terraform output must contain more than 0 service accounts.")
 				// create regex to validate service accounts emails
-				saRegex := `^[a-zA-Z0-9_+-]+@[a-zA-Z0-9-].iam.gserviceaccount.com$`
+				saRegex := `^[a-zA-Z0-9_+-]+@[a-zA-Z0-9-]+.iam.gserviceaccount.com$`
 				re := regexp.MustCompile(saRegex)
 				for _, sa := range cluster_service_accounts {
 					assert.True(re.MatchString(sa.String()), "The cluster SA value must be a Google Service Account")


### PR DESCRIPTION
* This PR adds instructions on how to update `backend.tf` on the repo
* Adds cluster service account output on 2-multitenant and tests for the new output
* The cluster SA will be used for assigning `artifactregistry.reader` on further PR's