### PR TITLE
fix(multitenant): avoid 5.44.0 & 6.2.0

### DIFF
--- a/2-multitenant/modules/env_baseline/versions.tf
+++ b/2-multitenant/modules/env_baseline/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5, < 7"
+      version = ">= 5, != 5.44.0, != 6.2.0, < 7"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5, < 7"
+      version = ">= 5, != 5.44.0, != 6.2.0, < 7"
     }
   }
 


### PR DESCRIPTION
Workaround for https://github.com/hashicorp/terraform-provider-google/issues/19428