### PR TITLE
fix: bumps config sync version, adds config sync enable true at creation

### DIFF
--- a/3-fleetscope/modules/env_baseline/acm.tf
+++ b/3-fleetscope/modules/env_baseline/acm.tf
@@ -62,8 +62,9 @@ resource "google_gke_hub_feature_membership" "acm_feature_member" {
   membership_location = regex(local.membership_re, each.key)[1]
 
   configmanagement {
-    version = "1.18.0"
+    version = "1.19.0"
     config_sync {
+      enabled       = true
       source_format = "unstructured"
       git {
         sync_repo                 = google_sourcerepo_repository.acm_repo.url

--- a/test/integration/fleetscope/fleetscope_test.go
+++ b/test/integration/fleetscope/fleetscope_test.go
@@ -122,7 +122,7 @@ func TestFleetscope(t *testing.T) {
 
 								assert.Equal("gcpserviceaccount", gkeFeatureOp.Get(configmanagementPath+".configSync.git.secretType").String(), fmt.Sprintf("Hub Feature %s should have git secret type equal to gcpserviceaccount", membershipName))
 								assert.Equal("unstructured", gkeFeatureOp.Get(configmanagementPath+".configSync.sourceFormat").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
-								assert.Equal("1.18.0", gkeFeatureOp.Get(configmanagementPath+".version").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
+								assert.Equal("1.19.0", gkeFeatureOp.Get(configmanagementPath+".version").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
 								assert.Equal(rootReconcilerSa, gkeFeatureOp.Get(configmanagementPath+".configSync.git.gcpServiceAccountEmail").String(), fmt.Sprintf("Hub Feature %s should have git service account type equal to %s", membershipName, rootReconcilerSa))
 							}
 						}


### PR DESCRIPTION
Fix build error https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/gke_hub_feature_membership#enabled


Error: Error creating FeatureMembership: googleapi: Error 400: InvalidValueError for field configSync.enabled: to install Config Sync, please set the field `configSync.enabled` to `true` explicitly; to uninstall Config Sync, please remove the Git or OCI configuration from Membership projects/957737439599/locations/us-central1/memberships/cluster-us-central1-nonproduction