### PR TITLE
fix: Ensures bucket encryption  

### DIFF
--- a/1-bootstrap/iam.tf
+++ b/1-bootstrap/iam.tf
@@ -186,3 +186,17 @@ resource "google_organization_iam_member" "org_iam_member" {
   member = "serviceAccount:${each.value.email}"
   org_id = var.org_id
 }
+
+data "google_storage_project_service_account" "gcs_account" {
+  project = var.project_id
+}
+
+resource "google_kms_crypto_key_iam_member" "bucket_crypto_key" {
+  for_each = var.bucket_kms_key != "" ? {
+    "encrypt" : "roles/cloudkms.cryptoKeyEncrypter",
+    "decrypt" : "roles/cloudkms.cryptoKeyDecrypter",
+  } : {}
+  crypto_key_id = var.bucket_kms_key
+  role          = each.value
+  member        = data.google_storage_project_service_account.gcs_account.member
+}

--- a/1-bootstrap/main.tf
+++ b/1-bootstrap/main.tf
@@ -75,16 +75,22 @@ module "cloudbuild_repositories" {
 
 module "tfstate_bucket" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
-  name          = "${var.bucket_prefix}-${var.project_id}-tf-state"
-  project_id    = var.project_id
-  location      = var.location
-  force_destroy = var.bucket_force_destroy
+  name                     = "${var.bucket_prefix}-${var.project_id}-tf-state"
+  project_id               = var.project_id
+  location                 = var.location
+  force_destroy            = var.bucket_force_destroy
+  public_access_prevention = "enforced"
 
-  encryption = {
+  encryption = var.bucket_kms_key == null ? {} : {
     default_kms_key_name = var.bucket_kms_key
   }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.bucket_force_destroy
+  } : {}
 
   log_bucket        = var.logging_bucket
   log_object_prefix = "tf-state-${var.project_id}"

--- a/1-bootstrap/tf_image.tf
+++ b/1-bootstrap/tf_image.tf
@@ -37,7 +37,7 @@ resource "google_service_account" "builder" {
 
 module "build_logs" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "cb-tf-builder-logs-${var.project_id}"
   project_id        = var.project_id
@@ -49,7 +49,15 @@ module "build_logs" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.bucket_force_destroy
+  } : {}
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122

--- a/5-appinfra/modules/cicd-pipeline/cloud-storage.tf
+++ b/5-appinfra/modules/cicd-pipeline/cloud-storage.tf
@@ -15,7 +15,7 @@
 # GCS bucket used as skaffold build cache
 module "build_cache" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "build-cache-${var.service_name}-${data.google_project.project.number}"
   project_id        = var.project_id
@@ -28,7 +28,14 @@ module "build_cache" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.buckets_force_destroy
+  } : {}
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122
@@ -48,7 +55,7 @@ resource "google_storage_bucket_iam_member" "build_cache_storage_admin" {
 
 module "release_source_development" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "release-source-development-${var.service_name}-${data.google_project.project.number}"
   project_id        = var.project_id
@@ -60,7 +67,14 @@ module "release_source_development" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.buckets_force_destroy
+  } : {}
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122

--- a/5-appinfra/modules/cicd-pipeline/pipelines.tf
+++ b/5-appinfra/modules/cicd-pipeline/pipelines.tf
@@ -55,7 +55,7 @@ resource "google_clouddeploy_target" "clouddeploy_targets" {
 # GCS bucket used by Cloud Deploy for delivery artifact storage
 module "delivery_artifacts" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   for_each = var.env_cluster_membership_ids
 
@@ -69,7 +69,14 @@ module "delivery_artifacts" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.buckets_force_destroy
+  } : {}
 
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)

--- a/5-appinfra/modules/hpc-ai-training-infra/container_image.tf
+++ b/5-appinfra/modules/hpc-ai-training-infra/container_image.tf
@@ -21,7 +21,7 @@ resource "google_service_account" "builder" {
 
 module "build_logs" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "cb-ai-builder-logs-${var.infra_project}"
   project_id        = var.infra_project
@@ -33,7 +33,14 @@ module "build_logs" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.bucket_force_destroy
+  } : {}
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122

--- a/5-appinfra/modules/hpc-monte-carlo-infra/bucket.tf
+++ b/5-appinfra/modules/hpc-monte-carlo-infra/bucket.tf
@@ -16,7 +16,7 @@
 
 module "stocks_data" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "${var.infra_project}-stocks-historical-data"
   project_id        = var.infra_project
@@ -29,8 +29,14 @@ module "stocks_data" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.bucket_force_destroy
+  } : {}
 
   depends_on = [time_sleep.wait_cmek_iam_propagation]
 }
-

--- a/5-appinfra/modules/hpc-monte-carlo-infra/container_image.tf
+++ b/5-appinfra/modules/hpc-monte-carlo-infra/container_image.tf
@@ -21,7 +21,7 @@ resource "google_service_account" "builder" {
 
 module "build_logs" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 10.0"
+  version = "~> 11.0"
 
   name              = "cb-mc-builder-logs-${var.infra_project}"
   project_id        = var.infra_project
@@ -34,7 +34,14 @@ module "build_logs" {
   public_access_prevention = "enforced"
 
   versioning = true
-  encryption = { default_kms_key_name = var.bucket_kms_key }
+  encryption = var.bucket_kms_key == null ? {} : {
+    default_kms_key_name = var.bucket_kms_key
+  }
+
+  internal_encryption_config = var.bucket_kms_key == null ? {
+    create_encryption_key = true
+    prevent_destroy       = !var.bucket_force_destroy
+  } : {}
 
   # Module does not support values not know before apply (member and role are used to create the index in for_each)
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122


### PR DESCRIPTION
- Forces bucket encryption if no kms key is provided.
- Grant KMS encrypt and decrypt roles to storage identity if kms key is provided.
- Bumps storage module to 11.0 