### PR TITLE
fix: bump acm from 1.19 to 1.22

### DIFF
--- a/3-fleetscope/modules/env_baseline/acm.tf
+++ b/3-fleetscope/modules/env_baseline/acm.tf
@@ -74,7 +74,7 @@ resource "google_gke_hub_feature_membership" "acm_feature_member" {
   membership_location = regex(local.membership_re, each.value)[1]
 
   configmanagement {
-    version = "1.19.0"
+    version = "1.22.0"
     config_sync {
       enabled       = true
       source_format = "unstructured"

--- a/test/integration/fleetscope/fleetscope_test.go
+++ b/test/integration/fleetscope/fleetscope_test.go
@@ -237,7 +237,7 @@ func TestFleetscope(t *testing.T) {
 								configmanagementPath := fmt.Sprintf("membershipSpecs.%s.configmanagement", membershipName)
 
 								assert.Equal("unstructured", gkeFeatureOp.Get(configmanagementPath+".configSync.sourceFormat").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
-								assert.Equal("1.19.0", gkeFeatureOp.Get(configmanagementPath+".version").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
+								assert.Equal("1.22.0", gkeFeatureOp.Get(configmanagementPath+".version").String(), fmt.Sprintf("Hub Feature %s should have source format equal to unstructured", membershipName))
 							}
 						}
 					case "policycontroller":


### PR DESCRIPTION
Bump ACM from 1.19.0 to 1.22.0 due deprecation.

`Error: Error creating FeatureMembership: googleapi: Error 400: InvalidValueError for field version: unsupported ACM version 1.19.0 for Membership projects/xxxxxxxx/locations/us-central1/memberships/cluster-us-central1-nonproduction, supported versions are 1.18.3, 1.20.0, 1.20.1, 1.20.2, 1.20.3, 1.21.0, 1.21.1, 1.21.2, 1.21.3, 1.22.0`