### PR TITLE
fix: fix error openpgp:key expired

### DIFF
--- a/.github/.tflint.repo.hcl
+++ b/.github/.tflint.repo.hcl
@@ -80,5 +80,5 @@ plugin "blueprint" {
 
 rule "terraform_required_version_range" {
   enabled = true
-  max_version = "1.6.1"
+  max_version = "1.6.6"
 }

--- a/.github/.tflint.repo.hcl
+++ b/.github/.tflint.repo.hcl
@@ -80,5 +80,5 @@ plugin "blueprint" {
 
 rule "terraform_required_version_range" {
   enabled = true
-  max_version = "1.6"
+  max_version = "1.6.1"
 }

--- a/3-fleetscope/envs/development/versions.tf
+++ b/3-fleetscope/envs/development/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.6.1"
 }

--- a/3-fleetscope/envs/nonproduction/versions.tf
+++ b/3-fleetscope/envs/nonproduction/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.6.1"
 }

--- a/3-fleetscope/envs/production/versions.tf
+++ b/3-fleetscope/envs/production/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 1.6"
+  required_version = ">= 1.6.1"
 }


### PR DESCRIPTION
Fixes error when downloading terraform 1.6 due error: https://github.com/hashicorp/terraform/issues/38418