### PR TITLE
fix: fix docker api version to 1.41

### DIFF
--- a/examples/agent/6-appsource/cloudbuild.yaml
+++ b/examples/agent/6-appsource/cloudbuild.yaml
@@ -55,5 +55,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/accounts/cloudbuild.yaml
+++ b/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/accounts/cloudbuild.yaml
@@ -65,5 +65,7 @@ steps:
       - "--gcs-source-staging-dir=$_SOURCE_STAGING_BUCKET/$SHORT_SHA"
 options:
   logging: CLOUD_LOGGING_ONLY
+  env:
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/frontend/cloudbuild.yaml
+++ b/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/frontend/cloudbuild.yaml
@@ -60,5 +60,7 @@ steps:
       - "--gcs-source-staging-dir=$_SOURCE_STAGING_BUCKET/$SHORT_SHA"
 options:
   logging: CLOUD_LOGGING_ONLY
+  env:
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/ledger/cloudbuild.yaml
+++ b/examples/cymbal-bank/6-appsource/cymbal-bank/cloudbuild-files/ledger/cloudbuild.yaml
@@ -62,5 +62,6 @@ options:
   env:
   - "TEAM=$_TEAM"
   - "SERVICE=$_SERVICE"
+  - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/cymbal-shop/6-appsource/cymbal-shop/cloudbuild.yaml
+++ b/examples/cymbal-shop/6-appsource/cymbal-shop/cloudbuild.yaml
@@ -142,5 +142,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/default-example/6-appsource/default-example/cloudbuild.yaml
+++ b/examples/default-example/6-appsource/default-example/cloudbuild.yaml
@@ -56,5 +56,6 @@ options:
   logging: CLOUD_LOGGING_ONLY
   env:
     - 'DOCKER_CLI_EXPERIMENTAL=enabled'
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'

--- a/examples/htc/6-appsource/cloudbuild.yaml
+++ b/examples/htc/6-appsource/cloudbuild.yaml
@@ -163,5 +163,7 @@ steps:
 
 options:
   logging: CLOUD_LOGGING_ONLY
+  env:
+    - 'DOCKER_API_VERSION=1.41'
   pool:
     name: '${_PRIVATE_POOL}'


### PR DESCRIPTION
Fix docker api version o cloud build file to avoid error "Error response from daemon: client version 1.52 is too new. Maximum supported API version is 1.41"
https://issuetracker.google.com/issues/467247261