### PR TITLE
fix: adds retryable errors

### DIFF
--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -38,7 +38,7 @@ jobs:
         folder: [test/integration]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-      - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: ${{ matrix.folder }}/go.mod
           cache-dependency-path: ${{ matrix.folder }}/go.sum
@@ -51,7 +51,7 @@ jobs:
               - ".github/workflows/go-lint.yaml"
       - if: steps.changes.outputs.src == 'true'
         name: golangci-lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: latest
           working-directory: ${{ matrix.folder }}

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -38,8 +38,8 @@ jobs:
       matrix:
         folder: [helpers/eab-deployer]
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: ${{ matrix.folder }}/go.mod
         cache-dependency-path: ${{ matrix.folder }}/go.sum

--- a/.github/workflows/lint-tf-min.yaml
+++ b/.github/workflows/lint-tf-min.yaml
@@ -24,6 +24,9 @@ env:
   TFENV_VERSION: v3.0.0
   TF_DEFAULT_MIN: "1.3.10"
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true

--- a/.github/workflows/lint-tf-min.yaml
+++ b/.github/workflows/lint-tf-min.yaml
@@ -32,7 +32,7 @@ jobs:
     name: 'lint-terraform-min'
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
+      - uses: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803' # v6.1.0
       - name: Cache tfenv
         id: cache-tfenv
         uses: actions/cache@v5

--- a/.github/workflows/lint-tf-min.yaml
+++ b/.github/workflows/lint-tf-min.yaml
@@ -35,7 +35,7 @@ jobs:
       - uses: 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803' # v6.1.0
       - name: Cache tfenv
         id: cache-tfenv
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/.tfenv
           key: tfenv_${{ env.TFENV_VERSION }}

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -361,6 +361,7 @@ steps:
       ]
     waitFor:
       - appfactory-teardown
+    allowFailure: true
 
   - id: multitenant-teardown
     name: "gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS"
@@ -372,6 +373,7 @@ steps:
       ]
     waitFor:
       - fleetscope-teardown
+    allowFailure: true
 
   - id: bootstrap-teardown
     name: "gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS"
@@ -386,6 +388,7 @@ steps:
     env:
       - "TF_VAR_org_id=$_ORG_ID"
       - "TF_VAR_billing_account=$_BILLING_ACCOUNT"
+    allowFailure: true
 
   - id: vpcsc-teardown
     name: "gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS"

--- a/examples/hpc/6-appsource/tutorial_files/settings.tpl.toml
+++ b/examples/hpc/6-appsource/tutorial_files/settings.tpl.toml
@@ -22,7 +22,7 @@ args = ["--project_id=${project_id}",
 limits={cpu="1000m", memory="1Gi"}
 node_selector={"cloud.google.com/gke-spot"="true"}
 job_annotations={"kueue.x-k8s.io/queue-name"="lq-hpc-team-b"}
-backoff_limit=50
+backoff_limit=60
 
 # Mounts, only GCS at this point
 

--- a/examples/llm-model/5-appinfra/llm-model/llamma-model/envs/shared/main.tf
+++ b/examples/llm-model/5-appinfra/llm-model/llamma-model/envs/shared/main.tf
@@ -25,7 +25,7 @@ locals {
     "cluster_project_id"      = p
     "model_armor_template_id" = module.model_armor_configuration[i].template.id
     "model_armor_location"    = var.region
-    "env_namespace_id"            = "vllm-model-${i}"
+    "env_namespace_id"        = "vllm-model-${i}"
   } }
 
 }

--- a/test/integration/agent/agent_appsource_test.go
+++ b/test/integration/agent/agent_appsource_test.go
@@ -219,7 +219,7 @@ func TestSourceAgent(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Logf(message)
+							t.Log(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/agent/agent_appsource_test.go
+++ b/test/integration/agent/agent_appsource_test.go
@@ -217,8 +217,9 @@ func TestSourceAgent(t *testing.T) {
 						logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 						logs := gcloud.RunCmd(t, logsCmd)
 						t.Logf("%s build-log: %s", serviceName, logs)
-						if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-							t.Logf("Re-trying rollout due to Cluster scalling.")
+						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+						if isRetryable {
+							t.Logf(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/agent/agent_appsource_test.go
+++ b/test/integration/agent/agent_appsource_test.go
@@ -219,7 +219,7 @@ func TestSourceAgent(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Log(message)
+							t.Logf("Re-trying rollout: %s", message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/cymbal_bank_test.go
+++ b/test/integration/appsource/cymbal_bank_test.go
@@ -294,7 +294,7 @@ func TestSourceCymbalBank(t *testing.T) {
 							t.Logf("%s build-log: %s", serviceName, logs)
 							isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 							if isRetryable {
-								t.Log(message)
+								t.Logf("Re-trying rollout: %s", message)
 								rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 								rolloutName := rolloutFullName[len(rolloutFullName)-1]
 								releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/cymbal_bank_test.go
+++ b/test/integration/appsource/cymbal_bank_test.go
@@ -292,8 +292,9 @@ func TestSourceCymbalBank(t *testing.T) {
 							logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 							logs := gcloud.RunCmd(t, logsCmd)
 							t.Logf("%s build-log: %s", serviceName, logs)
-							if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-								t.Logf("Re-trying rollout due to Cluster scalling.")
+							isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+							if isRetryable {
+								t.Log(message)
 								rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 								rolloutName := rolloutFullName[len(rolloutFullName)-1]
 								releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/cymbal_shop_test.go
+++ b/test/integration/appsource/cymbal_shop_test.go
@@ -180,8 +180,9 @@ func TestSourceCymbalShop(t *testing.T) {
 						logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 						logs := gcloud.RunCmd(t, logsCmd)
 						t.Logf("%s build-log: %s", serviceName, logs)
-						if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-							t.Logf("Re-trying rollout due to Cluster scalling.")
+						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+						if isRetryable {
+							t.Logf(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/cymbal_shop_test.go
+++ b/test/integration/appsource/cymbal_shop_test.go
@@ -182,7 +182,7 @@ func TestSourceCymbalShop(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Logf(message)
+							t.Log(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/cymbal_shop_test.go
+++ b/test/integration/appsource/cymbal_shop_test.go
@@ -182,7 +182,7 @@ func TestSourceCymbalShop(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Log(message)
+							t.Logf("Re-trying rollout: %s", message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/hello_world_test.go
+++ b/test/integration/appsource/hello_world_test.go
@@ -180,7 +180,7 @@ func TestSourceHelloWorld(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Logf(message)
+							t.Log(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/hello_world_test.go
+++ b/test/integration/appsource/hello_world_test.go
@@ -178,8 +178,9 @@ func TestSourceHelloWorld(t *testing.T) {
 						logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 						logs := gcloud.RunCmd(t, logsCmd)
 						t.Logf("%s build-log: %s", serviceName, logs)
-						if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-							t.Logf("Re-trying rollout due to Cluster scalling.")
+						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+						if isRetryable {
+							t.Logf(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/appsource/hello_world_test.go
+++ b/test/integration/appsource/hello_world_test.go
@@ -180,7 +180,7 @@ func TestSourceHelloWorld(t *testing.T) {
 						t.Logf("%s build-log: %s", serviceName, logs)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Log(message)
+							t.Logf("Re-trying rollout: %s", message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/cymbal-bank/e2e_single_project_test.go
+++ b/test/integration/cymbal-bank/e2e_single_project_test.go
@@ -21,6 +21,7 @@ import (
 	"net/http/cookiejar"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
 	"github.com/gruntwork-io/terratest/modules/retry"
@@ -76,6 +77,8 @@ func TestAppE2ECymbalBankSingleProject(t *testing.T) {
 				statusCode,
 			)
 		}
+
+		time.Sleep(60 * time.Second)
 
 		resp, err := login(ctx, client, ipAddress)
 

--- a/test/integration/cymbal-bank/e2e_test.go
+++ b/test/integration/cymbal-bank/e2e_test.go
@@ -80,6 +80,8 @@ func TestCymbalBankE2E(t *testing.T) {
 			)
 		}
 
+		time.Sleep(60 * time.Second)
+
 		resp, err := login(ctx, client, ipAddress)
 
 		// check if the server replied with authentication cookie

--- a/test/integration/fleetscope/fleetscope_test.go
+++ b/test/integration/fleetscope/fleetscope_test.go
@@ -252,7 +252,8 @@ func TestFleetscope(t *testing.T) {
 							// ensure config-sync resources are present in cluster
 							_, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "rootsyncs.configsync.gke.io", "-n", "config-management-system", "root-sync", "-o", "jsonpath='{.status}'")
 							if err != nil {
-								if !strings.Contains(err.Error(), "Error from server (NotFound): rootsyncs.configsync.gke.io \"root-sync\" not found") {
+								if !strings.Contains(err.Error(), "Error from server (NotFound): rootsyncs.configsync.gke.io \"root-sync\" not found") &&
+									!strings.Contains(err.Error(), "the server doesn't have a resource type \"rootsyncs\"") {
 									t.Logf("Config-Sync error '%s' \n.", err.Error())
 									return false, err
 								} else {

--- a/test/integration/llm-model/llm_model_appsource_test.go
+++ b/test/integration/llm-model/llm_model_appsource_test.go
@@ -205,7 +205,7 @@ func TestSourceLLMModel(t *testing.T) {
 						logs := gcloud.RunCmd(t, logsCmd)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Logf(message)
+							t.Log(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/llm-model/llm_model_appsource_test.go
+++ b/test/integration/llm-model/llm_model_appsource_test.go
@@ -205,7 +205,7 @@ func TestSourceLLMModel(t *testing.T) {
 						logs := gcloud.RunCmd(t, logsCmd)
 						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 						if isRetryable {
-							t.Log(message)
+							t.Logf("Re-trying rollout: %s", message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/llm-model/llm_model_appsource_test.go
+++ b/test/integration/llm-model/llm_model_appsource_test.go
@@ -203,9 +203,9 @@ func TestSourceLLMModel(t *testing.T) {
 					} else {
 						logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 						logs := gcloud.RunCmd(t, logsCmd)
-						t.Logf("%s build-log: %s", serviceName, logs)
-						if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-							t.Logf("Re-trying rollout due to Cluster scalling.")
+						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+						if isRetryable {
+							t.Logf(message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
+++ b/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
@@ -302,7 +302,7 @@ func TestSingleProjectSourceCymbalBank(t *testing.T) {
 							t.Logf("%s build-log: %s", serviceName, logs)
 							isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 							if isRetryable {
-								t.Logf(message)
+								t.Log(message)
 								rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 								rolloutName := rolloutFullName[len(rolloutFullName)-1]
 								releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
+++ b/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
@@ -300,8 +300,9 @@ func TestSingleProjectSourceCymbalBank(t *testing.T) {
 							logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 							logs := gcloud.RunCmd(t, logsCmd)
 							t.Logf("%s build-log: %s", serviceName, logs)
-							if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-								t.Logf("Re-trying rollout due to Cluster scalling.")
+							isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+							if isRetryable {
+								t.Logf(message)
 								rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 								rolloutName := rolloutFullName[len(rolloutFullName)-1]
 								releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
+++ b/test/integration/standalone_single_project/cymbal_bank_single_project_test.go
@@ -302,7 +302,7 @@ func TestSingleProjectSourceCymbalBank(t *testing.T) {
 							t.Logf("%s build-log: %s", serviceName, logs)
 							isRetryable, message := testutils.IsDeploymentRetryableError(logs)
 							if isRetryable {
-								t.Log(message)
+								t.Logf("Re-trying rollout: %s", message)
 								rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 								rolloutName := rolloutFullName[len(rolloutFullName)-1]
 								releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -73,6 +73,8 @@ var (
 
 		".*502.*": "Bad Gateway",
 
+		".*Error 400: Feature has associated resources that should be cleaned up before deletion.*": "Waiting Fleetscope service cleanup",
+
 		".*Error waiting for deleting GKE cluster.*": "Error waiting for deleting GKE cluster: Calling fleet operation service DeleteMembership, please ensure fleet service account has access to the project.",
 	}
 

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -84,6 +84,7 @@ var (
 		".*Insufficient CPU.*":                          "Waiting cluster to scale up - CPU.",
 		".*didn't match Pod's node affinity/selector.*": "Waiting cluster to scale up - machine/GPU type.",
 		".*FailedScaleUp.*":                             "Waiting cluster to scale up - Resources availability.",
+		".*Error from server (AlreadyExists).*":         "Resource already exists, waiting stabilize.",
 	}
 )
 

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -76,6 +76,7 @@ var (
 		".*Error 400: Feature has associated resources that should be cleaned up before deletion.*": "Waiting Fleetscope service cleanup",
 
 		".*Error waiting for deleting GKE cluster.*": "Error waiting for deleting GKE cluster: Calling fleet operation service DeleteMembership, please ensure fleet service account has access to the project.",
+     ".*Could not connect to server.*": "Network error.",
 	}
 
 	RetryableDeploymentErrors = map[string]string{

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -86,7 +86,7 @@ var (
 		".*Insufficient CPU.*":                          "Waiting cluster to scale up - CPU.",
 		".*didn't match Pod's node affinity/selector.*": "Waiting cluster to scale up - machine/GPU type.",
 		".*FailedScaleUp.*":                             "Waiting cluster to scale up - Resources availability.",
-		".*Error from server (AlreadyExists).*":         "Resource already exists, waiting stabilize.",
+		".*Error from server \\(AlreadyExists\\).*":         "Resource already exists, waiting stabilize.",
 	}
 )
 

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -76,7 +76,7 @@ var (
 		".*Error 400: Feature has associated resources that should be cleaned up before deletion.*": "Waiting Fleetscope service cleanup",
 
 		".*Error waiting for deleting GKE cluster.*": "Error waiting for deleting GKE cluster: Calling fleet operation service DeleteMembership, please ensure fleet service account has access to the project.",
-     ".*Could not connect to server.*": "Network error.",
+		".*Could not connect to server.*": "Network error.",
 	}
 
 	RetryableDeploymentErrors = map[string]string{

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -14,6 +14,8 @@
 
 package testutils
 
+import "regexp"
+
 var (
 	RetryableTransientErrors = map[string]string{
 		// Error 409: unable to queue the operation
@@ -68,5 +70,29 @@ var (
 		".*Error 400.*Invalid value for field.*resource.networkInterfaces[0].subnetwork.*:.*projects/.*/regions/.*/subnetworks/.*. The referenced subnetwork resource cannot be found.*": "Network propagation",
 
 		".*Error: Error creating FeatureMembership: Resource already exists - apply blocked by lifecycle params.*": "Duplicated membership request",
+
+		".*502.*": "Bad Gateway",
+	}
+
+	RetryableDeploymentErrors = map[string]string{
+		".*context deadline exceeded.*": "Timeout connection.",
+		".*502.*":                       "Bad Gateway",
+		".*Waiting for deployments to stabilize.*":      "Waiting for deployments to stabilize.",
+		".*Insufficient memory.*":                       "Waiting cluster to scale up - memory.",
+		".*Insufficient CPU.*":                          "Waiting cluster to scale up - CPU.",
+		".*didn't match Pod's node affinity/selector.*": "Waiting cluster to scale up - machine/GPU type.",
+		".*FailedScaleUp.*":                             "Waiting cluster to scale up - Resources availability.",
 	}
 )
+
+func IsDeploymentRetryableError(errMessage string) (bool, string) {
+	for pattern, msg := range RetryableDeploymentErrors {
+		// Use regexp.MatchString to check if the error message matches the pattern
+		matched, err := regexp.MatchString(pattern, errMessage)
+		if err == nil && matched {
+			return true, msg
+		}
+	}
+
+	return false, ""
+}

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -72,6 +72,8 @@ var (
 		".*Error: Error creating FeatureMembership: Resource already exists - apply blocked by lifecycle params.*": "Duplicated membership request",
 
 		".*502.*": "Bad Gateway",
+
+		".*Error waiting for deleting GKE cluster.*": "Error waiting for deleting GKE cluster: Calling fleet operation service DeleteMembership, please ensure fleet service account has access to the project.",
 	}
 
 	RetryableDeploymentErrors = map[string]string{

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -85,11 +85,21 @@ var (
 	}
 )
 
-func IsDeploymentRetryableError(errMessage string) (bool, string) {
+var compiledRetryableErrors = make(map[*regexp.Regexp]string)
+
+func init() {
+	// Compile all regex patterns once and store them
 	for pattern, msg := range RetryableDeploymentErrors {
-		// Use regexp.MatchString to check if the error message matches the pattern
-		matched, err := regexp.MatchString(pattern, errMessage)
-		if err == nil && matched {
+		compiledRegex := regexp.MustCompile(pattern)
+		compiledRetryableErrors[compiledRegex] = msg
+	}
+}
+
+// IsDeploymentRetryableError checks the error using pre-compiled regular expressions
+func IsDeploymentRetryableError(errMessage string) (bool, string) {
+	for regex, msg := range compiledRetryableErrors {
+		// MatchString on a compiled regex is much faster
+		if regex.MatchString(errMessage) {
 			return true, msg
 		}
 	}

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -76,6 +76,7 @@ var (
 		".*Error 400: Feature has associated resources that should be cleaned up before deletion.*": "Waiting Fleetscope service cleanup",
 
 		".*Error waiting for deleting GKE cluster.*": "Error waiting for deleting GKE cluster: Calling fleet operation service DeleteMembership, please ensure fleet service account has access to the project.",
+
 		".*Could not connect to server.*": "Network error.",
 	}
 
@@ -87,7 +88,7 @@ var (
 		".*Insufficient CPU.*":                          "Waiting cluster to scale up - CPU.",
 		".*didn't match Pod's node affinity/selector.*": "Waiting cluster to scale up - machine/GPU type.",
 		".*FailedScaleUp.*":                             "Waiting cluster to scale up - Resources availability.",
-		".*Error from server \\(AlreadyExists\\).*":         "Resource already exists, waiting stabilize.",
+		".*Error from server \\(AlreadyExists\\).*":     "Resource already exists, waiting stabilize.",
 	}
 )
 

--- a/test/setup/harness/gitlab/gitlab_vm.tf
+++ b/test/setup/harness/gitlab/gitlab_vm.tf
@@ -19,6 +19,12 @@ locals {
   gitlab_network_id_without_location = replace(var.network_id, "locations/", "")
   gitlab_network_url                 = "https://www.googleapis.com/compute/v1/projects/${var.project_id}/global/networks/${var.network_name}"
   gitlab_vm_ip_range                 = "10.2.2.0/24"
+  machine_type                       = "n2-standard-8"
+  zones_with_machine_type = [
+    for zone_name, result in data.google_compute_machine_types.available : zone_name
+    if length(result.machine_types) > 0
+  ]
+  selected_zone = try(local.zones_with_machine_type[0], null)
 }
 
 data "google_project" "gitlab_project" {
@@ -117,11 +123,24 @@ resource "time_sleep" "waits_iam_propagation" {
   ]
 }
 
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+  status  = "UP"
+}
+
+data "google_compute_machine_types" "available" {
+  for_each = toset(data.google_compute_zones.available.names)
+  zone     = each.value
+  project  = module.gitlab_project.project_id
+  filter   = "name = ${local.machine_type}"
+}
+
 resource "google_compute_instance" "default" {
   name         = "gitlab"
   project      = var.project_id
-  machine_type = "n2-standard-4"
-  zone         = "us-central1-a"
+  machine_type = local.machine_type
+  zone         = local.selected_zone
 
   tags = ["git-vm", "direct-gateway-access"]
 

--- a/test/setup/harness/gitlab/gitlab_vm.tf
+++ b/test/setup/harness/gitlab/gitlab_vm.tf
@@ -132,7 +132,7 @@ data "google_compute_zones" "available" {
 data "google_compute_machine_types" "available" {
   for_each = toset(data.google_compute_zones.available.names)
   zone     = each.value
-  project  = module.gitlab_project.project_id
+  project  = var.project_id
   filter   = "name = ${local.machine_type}"
 }
 


### PR DESCRIPTION
This PR centralize the deployment retryable errors.
Adds new errors to be retryed.
Bumps github actions dependencies (node 20 deprecation)
Set read only permission in tf-min-lint
Adds sleep on cymbal bank e2e tests after first heartbeat to avoid error 404 in login service