### PR TITLE
fix: resolve sources of CI flakiness and IAM propagation issues

### DIFF
--- a/examples/default-example/standalone-single-project/5-secure-pipeline.tf
+++ b/examples/default-example/standalone-single-project/5-secure-pipeline.tf
@@ -69,9 +69,13 @@ resource "google_project_iam_member" "cloudbuid_builder" {
 }
 
 resource "time_sleep" "wait_propagation" {
-  create_duration = "30s"
+  create_duration = "60s"
 
   depends_on = [
+    google_project_iam_member.assign_permissions,
+    google_project_iam_member.assign_permissions_service_agent,
+    google_project_iam_member.sd_viewer,
+    google_project_iam_member.access_network,
     google_access_context_manager_service_perimeter_egress_policy.egress_policy,
     google_access_context_manager_service_perimeter_dry_run_egress_policy.egress_policy,
     google_access_context_manager_service_perimeter_ingress_policy.cymbal_bank_private_deployment,
@@ -120,9 +124,6 @@ module "cicd" {
   binary_authorization_repository_id = module.binary_autz.binary_authorization_repository_id
 
   depends_on = [
-    google_access_context_manager_service_perimeter_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_dry_run_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_ingress_policy.cymbal_bank_private_deployment,
-    google_project_service.required_services
+    time_sleep.wait_propagation
   ]
 }

--- a/examples/standalone_single_project/5-appinfra.tf
+++ b/examples/standalone_single_project/5-appinfra.tf
@@ -230,7 +230,7 @@ resource "google_project_iam_member" "access_network" {
 }
 
 resource "time_sleep" "wait_propagation" {
-  create_duration = "30s"
+  create_duration = "60s"
 
   depends_on = [
     google_project_iam_member.assign_permissions,
@@ -277,9 +277,7 @@ module "cicd" {
   binary_authorization_repository_id = var.binary_authorization_repository_id
 
   depends_on = [
-    google_access_context_manager_service_perimeter_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_dry_run_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_ingress_policy.cymbal_bank_private_deployment
+    time_sleep.wait_propagation
   ]
 }
 

--- a/examples/standalone_single_project_confidential_nodes/5-appinfra.tf
+++ b/examples/standalone_single_project_confidential_nodes/5-appinfra.tf
@@ -230,7 +230,7 @@ resource "google_project_iam_member" "access_network" {
 }
 
 resource "time_sleep" "wait_propagation" {
-  create_duration = "30s"
+  create_duration = "60s"
 
   depends_on = [
     google_project_iam_member.assign_permissions,
@@ -277,9 +277,7 @@ module "cicd" {
   binary_authorization_repository_id = var.binary_authorization_repository_id
 
   depends_on = [
-    google_access_context_manager_service_perimeter_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_dry_run_egress_policy.egress_policy,
-    google_access_context_manager_service_perimeter_ingress_policy.cymbal_bank_private_deployment
+    time_sleep.wait_propagation
   ]
 }
 

--- a/modules/binary-authz-build-image/bin-authz-image.tf
+++ b/modules/binary-authz-build-image/bin-authz-image.tf
@@ -41,6 +41,15 @@ resource "google_artifact_registry_repository_iam_member" "builder_on_attestatio
   member     = "serviceAccount:${local.service_account_email}"
 }
 
+resource "time_sleep" "wait_iam_propagation" {
+  create_duration = "45s"
+
+  depends_on = [
+    google_artifact_registry_repository.attestation_image,
+    google_artifact_registry_repository_iam_member.builder_on_attestation_repo,
+  ]
+}
+
 module "build_binary_authz_image" {
   source  = "terraform-google-modules/gcloud/google"
   version = "~> 4.0"
@@ -53,5 +62,5 @@ module "build_binary_authz_image" {
   create_cmd_entrypoint = "bash"
   create_cmd_body       = "${local.cmd_prompt} || ( sleep 45 && ${local.cmd_prompt})"
 
-  module_depends_on = var.module_dependencies
+  module_depends_on = concat([time_sleep.wait_iam_propagation], var.module_dependencies)
 }

--- a/modules/binary-authz-build-image/outputs.tf
+++ b/modules/binary-authz-build-image/outputs.tf
@@ -27,9 +27,11 @@ output "binary_authz_image__repository_name" {
 output "binary_authorization_repository_id" {
   description = "The ID of the Repository where binary attestation image is stored."
   value       = google_artifact_registry_repository.attestation_image.id
+  depends_on  = [module.build_binary_authz_image]
 }
 
 output "binary_authorization_image" {
   description = "Image tag to create attestations."
   value       = local.binary_auth_image_tag
+  depends_on  = [module.build_binary_authz_image]
 }

--- a/modules/binary-authz-build-image/versions.tf
+++ b/modules/binary-authz-build-image/versions.tf
@@ -21,6 +21,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 6.6, < 8"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.12.0"
+    }
   }
 
   provider_meta "google" {

--- a/test/integration/default-example/hello_world_deploy_single_project_test.go
+++ b/test/integration/default-example/hello_world_deploy_single_project_test.go
@@ -179,8 +179,9 @@ func TestSingleProjectSourceHelloWorld(t *testing.T) {
 						logsCmd := fmt.Sprintf("builds log %s --project=%s --region=%s", rollouts[0].Get("deployingBuild").String(), projectID, region)
 						logs := gcloud.RunCmd(t, logsCmd)
 						t.Logf("%s build-log: %s", serviceName, logs)
-						if strings.Contains(logs, "Waiting for deployments to stabilize") || strings.Contains(logs, "Insufficient memory") || strings.Contains(logs, "Insufficient CPU") || strings.Contains(logs, "didn't match Pod's node affinity/selector") || strings.Contains(logs, "FailedScaleUp") {
-							t.Logf("Re-trying rollout due to Cluster scalling.")
+						isRetryable, message := testutils.IsDeploymentRetryableError(logs)
+						if isRetryable {
+							t.Logf("Re-trying rollout: %s", message)
 							rolloutFullName := strings.Split(rollouts[0].Get("name").String(), "/")
 							rolloutName := rolloutFullName[len(rolloutFullName)-1]
 							releaseNameParts := strings.Split(releaseName, "/")

--- a/test/integration/default-example/hello_world_e2e_test.go
+++ b/test/integration/default-example/hello_world_e2e_test.go
@@ -15,7 +15,6 @@
 package default_example
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -55,15 +54,15 @@ func TestHelloWorldSingleProjectE2E(t *testing.T) {
 				return func() (bool, error) {
 					logs, err := getLogs(t)
 					if err != nil {
-						t.Fatal(err)
+						t.Logf("Pod logs not yet available (%v), will retry.", err)
+						return true, nil
 					}
 					if strings.Contains(logs, "Hello world!") {
+						t.Log("Application is running: 'Hello world!' found in logs.")
 						return false, nil
-					} else if strings.Contains(logs, "container creating") {
-						return true, nil
-					} else {
-						return false, fmt.Errorf("Unable to get hello world container running.")
 					}
+					t.Logf("Application starting up, current logs: %s", logs)
+					return true, nil
 				}
 			}
 			utils.Poll(t, pollApplication(), 40, 60*time.Second)

--- a/test/integration/default-example/standalone_single_project_test.go
+++ b/test/integration/default-example/standalone_single_project_test.go
@@ -215,7 +215,7 @@ func TestStandaloneSingleProjectDefaultExample(t *testing.T) {
 
 	standaloneSingleProjT.DefineTeardown(func(assert *assert.Assertions) {
 		// removes firewall rules created by the service but not being deleted.
-		firewallRules := gcloud.Runf(t, "compute firewall-rules list  --project %s --filter=\"gke\"", projectID).Array()
+		firewallRules := gcloud.Runf(t, "compute firewall-rules list  --project %s --filter=\"mcsd\"", projectID).Array()
 		for i := range firewallRules {
 			gcloud.Runf(t, "compute firewall-rules delete %s --project %s -q", firewallRules[i].Get("name"), projectID)
 		}

--- a/test/integration/fleetscope/fleetscope_test.go
+++ b/test/integration/fleetscope/fleetscope_test.go
@@ -246,20 +246,13 @@ func TestFleetscope(t *testing.T) {
 						}
 
 						pollConfigSync := func() (bool, error) {
-							retry := false
 							// ensure config-sync resources are present in cluster
 							_, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "rootsyncs.configsync.gke.io", "-n", "config-management-system", "root-sync", "-o", "jsonpath='{.status}'")
 							if err != nil {
-								if !strings.Contains(err.Error(), "Error from server (NotFound): rootsyncs.configsync.gke.io \"root-sync\" not found") &&
-									!strings.Contains(err.Error(), "the server doesn't have a resource type \"rootsyncs\"") {
-									t.Logf("Config-Sync error '%s' \n.", err.Error())
-									return false, err
-								} else {
-									t.Log("Config-Sync not yet installed, will try polling again after sleeping.")
-									retry = true
-								}
+								t.Logf("Config-Sync not yet ready or error '%s', will retry polling.", err.Error())
+								return true, nil
 							}
-							return retry, nil
+							return false, nil
 						}
 
 						utils.Poll(t, pollConfigSync, 20, 40*time.Second)

--- a/test/integration/multi_cluster_discovery/multi_cluster_discovery_test.go
+++ b/test/integration/multi_cluster_discovery/multi_cluster_discovery_test.go
@@ -56,6 +56,8 @@ func TestMultiClusterDiscovery(t *testing.T) {
 	if forkRepository == "" || branch == "" {
 		forkRepository = "https://github.com/GoogleCloudPlatform/terraform-google-enterprise-application"
 		branch = "main"
+	}
+	if configSyncPath == "" {
 		configSyncPath = fmt.Sprintf("examples/cymbal-bank/3-fleetscope/config-sync/%s", envName)
 	}
 
@@ -269,10 +271,12 @@ func TestMultiClusterDiscovery(t *testing.T) {
 					// get kubectl namespaces and store them on currentClusterNamespaces slice
 					output, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "ns", "-o", "json")
 					if err != nil {
-						t.Fatal(err)
+						t.Logf("Error getting namespaces: %v, will retry", err)
+						return true, nil
 					}
 					if !gjson.Valid(output) {
-						t.Fatalf("Error parsing output, invalid json: %s", output)
+						t.Logf("Error parsing output, invalid json: %s, will retry", output)
+						return true, nil
 					}
 					jsonOutput := gjson.Parse(output)
 					var currentClusterNamespaces []string
@@ -356,20 +360,13 @@ func TestMultiClusterDiscovery(t *testing.T) {
 						}
 
 						pollConfigSync := func() (bool, error) {
-							retry := false
 							// ensure config-sync resources are present in cluster
 							_, err := k8s.RunKubectlAndGetOutputE(t, k8sOpts, "get", "rootsyncs.configsync.gke.io", "-n", "config-management-system", "root-sync", "-o", "jsonpath='{.status}'")
 							if err != nil {
-								if !strings.Contains(err.Error(), "Error from server (NotFound): rootsyncs.configsync.gke.io \"root-sync\" not found") &&
-									!strings.Contains(err.Error(), "the server doesn't have a resource type \"rootsyncs\"") {
-									t.Logf("Config-Sync error '%s' \n.", err.Error())
-									return false, err
-								} else {
-									t.Log("Config-Sync not yet installed, will try polling again after sleeping.")
-									retry = true
-								}
+								t.Logf("Config-Sync not yet ready or error '%s', will retry polling.", err.Error())
+								return true, nil
 							}
-							return retry, nil
+							return false, nil
 						}
 
 						utils.Poll(t, pollConfigSync, 20, 40*time.Second)
@@ -469,8 +466,8 @@ func TestMultiClusterDiscovery(t *testing.T) {
 						t.Logf("noError() jsonOutput: %v", jsonOutput.String())
 
 						t.Logf("source.errorSummary equals {} or empty: %v", jsonOutput.Get("source.errorSummary").String() == "{}" || jsonOutput.Get("source.errorSummary").String() == "")
-						t.Logf("sync.errorSummary equals {} or empty: %v", jsonOutput.Get("sync.errorSummary").String() == "{}" || jsonOutput.Get("source.errorSummary").String() == "")
-						t.Logf("rendering.errorSummary equals {} or empty: %v", jsonOutput.Get("rendering.errorSummary").String() == "{}" || jsonOutput.Get("source.errorSummary").String() == "")
+						t.Logf("sync.errorSummary equals {} or empty: %v", jsonOutput.Get("sync.errorSummary").String() == "{}" || jsonOutput.Get("sync.errorSummary").String() == "")
+						t.Logf("rendering.errorSummary equals {} or empty: %v", jsonOutput.Get("rendering.errorSummary").String() == "{}" || jsonOutput.Get("rendering.errorSummary").String() == "")
 
 						return (jsonOutput.Get("sync.errorSummary").String() == "{}" || jsonOutput.Get("sync.errorSummary").String() == "") &&
 							(jsonOutput.Get("source.errorSummary").String() == "{}" || jsonOutput.Get("source.errorSummary").String() == "") &&

--- a/test/integration/testutils/retry.go
+++ b/test/integration/testutils/retry.go
@@ -30,6 +30,36 @@ var (
 		// Error 403: Kubernetes Engine API has not been used in project {} before or it is disabled.
 		".*Error 403.*Kubernetes Engine API is not enabled for this project*": "Kubernetes Engine API not enabled",
 
+		// General API enablement propagation
+		".*Error 403.*has not been used in project.*before or it is disabled.*": "API enablement propagation.",
+		".*Error 403.*Access Not Configured.*":                                  "API access configuration propagation.",
+
+		// IAM / Permission propagation errors
+		".*Error 403.*Permission.*denied.*":                                 "IAM permission denied / propagation.",
+		".*Error 403.*The caller does not have permission.*":                "IAM permission propagation.",
+		".*Error 403.*caller does not have required permission.*":            "IAM permission propagation.",
+		".*Error 403.*does not have.*permission.*":                           "IAM permission propagation.",
+		".*Error 403.*is not authorized to perform this operation.*":         "IAM permission propagation.",
+		".*Error code 7, message: Permission denied.*":                       "IAM permission denied.",
+		".*Error code 7, message: The caller does not have permission.*":     "IAM permission propagation.",
+		".*Permission iam.serviceAccounts.actAs denied on service account.*": "IAM actAs permission propagation.",
+		".*Permission 'resourcemanager.projects.get' denied on resource.*":   "Project IAM permission propagation.",
+		".*roles/iam.serviceAccountTokenCreator.*":                            "IAM service account token creator propagation.",
+		".*roles/iam.serviceAccountUser.*":                                    "IAM service account user propagation.",
+		".*does not have storage.objects.*":                                  "Storage IAM permission propagation.",
+		".*Permission 'cloudkms.cryptoKey.*":                                 "Cloud KMS IAM permission propagation.",
+		".*Permission 'artifactregistry.repositories.*":                      "Artifact Registry IAM permission propagation.",
+
+		// Rate limit / Quota / Internal server errors
+		".*rateLimitExceeded.*":               "Rate limit exceeded.",
+		".*Quota exceeded for quota metric.*": "Quota exceeded.",
+		".*Error 429.*":                       "Too Many Requests / Rate limit.",
+		".*Error 500.*":                       "Internal server error.",
+		".*Error 503.*":                       "Service unavailable.",
+		".*connection reset by peer.*":        "Connection reset.",
+		".*TLS handshake timeout.*":           "TLS handshake timeout.",
+		".*i/o timeout.*":                      "I/O timeout.",
+
 		// google_gke_hub_feature - Error: Error waiting to create Feature: Error waiting for Creating Feature: Error code 13, message: an internal error has occurred
 		".*Error waiting for Creating Feature: Error code 13, message: an internal error has occurred*.": "Error creating feature",
 
@@ -81,14 +111,22 @@ var (
 	}
 
 	RetryableDeploymentErrors = map[string]string{
-		".*context deadline exceeded.*": "Timeout connection.",
-		".*502.*":                       "Bad Gateway",
-		".*Waiting for deployments to stabilize.*":      "Waiting for deployments to stabilize.",
-		".*Insufficient memory.*":                       "Waiting cluster to scale up - memory.",
-		".*Insufficient CPU.*":                          "Waiting cluster to scale up - CPU.",
-		".*didn't match Pod's node affinity/selector.*": "Waiting cluster to scale up - machine/GPU type.",
-		".*FailedScaleUp.*":                             "Waiting cluster to scale up - Resources availability.",
-		".*Error from server \\(AlreadyExists\\).*":     "Resource already exists, waiting stabilize.",
+		".*context deadline exceeded.*":                                      "Timeout connection.",
+		".*502.*":                                                           "Bad Gateway",
+		".*Waiting for deployments to stabilize.*":                          "Waiting for deployments to stabilize.",
+		".*Insufficient memory.*":                                           "Waiting cluster to scale up - memory.",
+		".*Insufficient CPU.*":                                              "Waiting cluster to scale up - CPU.",
+		".*didn't match Pod's node affinity/selector.*":                     "Waiting cluster to scale up - machine/GPU type.",
+		".*FailedScaleUp.*":                                                 "Waiting cluster to scale up - Resources availability.",
+		".*Error from server \\(AlreadyExists\\).*":                         "Resource already exists, waiting stabilize.",
+		".*Client\\.Timeout exceeded while awaiting headers.*":              "Client timeout awaiting headers.",
+		".*connection refused.*":                                            "Connection refused, waiting stabilize.",
+		".*connection reset by peer.*":                                      "Connection reset by peer.",
+		".*broken pipe.*":                                                   "Broken pipe.",
+		".*TLS handshake timeout.*":                                         "TLS handshake timeout.",
+		".*i/o timeout.*":                                                   "I/O timeout.",
+		".*the server is currently unable to handle the request.*":          "Server currently unable to handle request.",
+		".*the server was unable to return a response in the time allotted.*": "Server timeout.",
 	}
 )
 

--- a/test/setup/harness/logging_bucket/main.tf
+++ b/test/setup/harness/logging_bucket/main.tf
@@ -32,18 +32,13 @@ module "logging_bucket" {
   versioning = true
   encryption = { default_kms_key_name = module.kms.keys["bucket"] }
 
-  # Module does not support values not know before apply (member and role are used to create the index in for_each)
-  # https://github.com/terraform-google-modules/terraform-google-cloud-storage/blob/v10.0.2/modules/simple_bucket/main.tf#L122
-  # iam_members = [
-  #   {
-  #     role   = "roles/storage.admin"
-  #     member = "serviceAccount:${google_service_account.gitlab_vm.email}"
-  #   },
-  #   {
-  #     role   = "roles/storage.admin"
-  #     member = "serviceAccount:${google_service_account.int_test.email}"
-  #   }
-  # ]
+  depends_on = [time_sleep.wait_cmek_iam_propagation]
+}
+
+resource "time_sleep" "wait_cmek_iam_propagation" {
+  create_duration = "60s"
+
+  depends_on = [module.kms]
 }
 
 resource "google_storage_bucket_iam_member" "logging_storage_admin" {
@@ -104,4 +99,14 @@ module "kms_attestor" {
     "${data.google_storage_project_service_account.ci_gcs_account.member},${"serviceAccount:${var.sa_email}"},serviceAccount:${var.cloud_build_sa}",
   ]
   prevent_destroy = false
+}
+
+resource "time_sleep" "wait_iam_propagation" {
+  create_duration = "30s"
+
+  depends_on = [
+    google_storage_bucket_iam_member.logging_storage_admin,
+    module.kms_attestor,
+    module.logging_bucket,
+  ]
 }

--- a/test/setup/harness/logging_bucket/outputs.tf
+++ b/test/setup/harness/logging_bucket/outputs.tf
@@ -15,17 +15,21 @@
  */
 
 output "project_id" {
-  value = var.seed_project_id
+  value      = var.seed_project_id
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "logging_bucket" {
-  value = module.logging_bucket.name
+  value      = module.logging_bucket.name
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "bucket_kms_key" {
-  value = module.kms.keys["bucket"]
+  value      = module.kms.keys["bucket"]
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "attestation_kms_key" {
-  value = module.kms_attestor.keys["attestation"]
+  value      = module.kms_attestor.keys["attestation"]
+  depends_on = [time_sleep.wait_iam_propagation]
 }

--- a/test/setup/harness/multitenant/iam.tf
+++ b/test/setup/harness/multitenant/iam.tf
@@ -35,3 +35,13 @@ resource "google_project_iam_member" "int_test_iam" {
   role    = "roles/resourcemanager.projectIamAdmin"
   member  = "serviceAccount:${var.sa_email}"
 }
+
+resource "time_sleep" "wait_iam_propagation" {
+  create_duration = "30s"
+
+  depends_on = [
+    google_project_iam_member.int_test_connection_admin,
+    google_project_iam_member.int_test_vpc,
+    google_project_iam_member.int_test_iam,
+  ]
+}

--- a/test/setup/harness/multitenant/outputs.tf
+++ b/test/setup/harness/multitenant/outputs.tf
@@ -23,14 +23,17 @@ output "envs" {
     network_self_link  = vpc.network_self_link,
     subnets_self_links = [for sub in vpc.subnets_self_links : sub if strcontains(sub, "subnetworks/eab")],
   } }
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "network_project_number" {
-  value = [for value in module.vpc_project : value.project_number]
+  value      = [for value in module.vpc_project : value.project_number]
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "network_project_id" {
-  value = [for value in module.vpc_project : value.project_id]
+  value      = [for value in module.vpc_project : value.project_id]
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "common_folder_id" {

--- a/test/setup/harness/single_project/bin-authz-image.tf
+++ b/test/setup/harness/single_project/bin-authz-image.tf
@@ -15,7 +15,7 @@
  */
 
 locals {
-  cmd_prompt = "gcloud builds submit ${path.module}/../../../../1-bootstrap/binauthz-attestation/. --tag ${local.binary_auth_image_tag} --project=${var.seed_project_id} --service-account=${var.sa_id} --gcs-log-dir=gs://${var.logging_bucket_name} --worker-pool=${var.workerpool_id} || ( sleep 45 && gcloud builds submit ${path.module}/../../1-bootstrap/binauthz-attestation/. --tag ${local.binary_auth_image_tag} --project=${var.seed_project_id} --service-account=${var.sa_id} --gcs-log-dir=gs://${var.logging_bucket_name} --worker-pool=${var.workerpool_id} )"
+  cmd_prompt = "gcloud builds submit ${path.module}/../../../../modules/binary-authz-build-image/binauthz-attestation/. --tag ${local.binary_auth_image_tag} --project=${var.seed_project_id} --service-account=${var.sa_id} --gcs-log-dir=gs://${var.logging_bucket_name} --worker-pool=${var.workerpool_id} || ( sleep 45 && gcloud builds submit ${path.module}/../../../../modules/binary-authz-build-image/binauthz-attestation/. --tag ${local.binary_auth_image_tag} --project=${var.seed_project_id} --service-account=${var.sa_id} --gcs-log-dir=gs://${var.logging_bucket_name} --worker-pool=${var.workerpool_id} )"
 
   binary_auth_image_version = "v1"
   binary_auth_image_tag     = "us-central1-docker.pkg.dev/${var.seed_project_id}/${google_artifact_registry_repository.attestation_image.name}/binauthz-attestation:${local.binary_auth_image_version}"
@@ -37,6 +37,15 @@ resource "google_artifact_registry_repository_iam_member" "builder_on_attestatio
   member     = "serviceAccount:${var.sa_email}"
 }
 
+resource "time_sleep" "wait_iam_propagation" {
+  create_duration = "45s"
+
+  depends_on = [
+    google_artifact_registry_repository_iam_member.builder_on_attestation_repo,
+    google_artifact_registry_repository.attestation_image,
+  ]
+}
+
 module "build_binary_authz_image" {
   source  = "terraform-google-modules/gcloud/google"
   version = "~> 4.0"
@@ -49,4 +58,6 @@ module "build_binary_authz_image" {
 
   create_cmd_entrypoint = "bash"
   create_cmd_body       = "${local.cmd_prompt} || ( sleep 45 && ${local.cmd_prompt})"
+
+  module_depends_on = [time_sleep.wait_iam_propagation]
 }

--- a/test/setup/harness/single_project/outputs.tf
+++ b/test/setup/harness/single_project/outputs.tf
@@ -31,7 +31,8 @@ output "single_project_cluster_subnetwork_self_link" {
 }
 
 output "binary_authorization_image" {
-  value = local.binary_auth_image_tag
+  value      = local.binary_auth_image_tag
+  depends_on = [module.build_binary_authz_image]
 }
 
 output "attestation_evaluation_mode" {
@@ -41,4 +42,5 @@ output "attestation_evaluation_mode" {
 output "binary_authorization_repository_id" {
   description = "The ID of the Repository where binary attestation image is stored."
   value       = google_artifact_registry_repository.attestation_image.id
+  depends_on  = [module.build_binary_authz_image]
 }

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -95,8 +95,30 @@ resource "google_organization_iam_member" "policyAdmin_role" {
   member = "serviceAccount:${google_service_account.int_test.email}"
 }
 
+resource "time_sleep" "wait_iam_propagation" {
+  create_duration = "60s"
+
+  depends_on = [
+    google_project_iam_member.int_test_connection_admin,
+    google_folder_iam_member.int_test_connection_admin,
+    google_project_iam_member.int_test,
+    google_organization_iam_member.organizationServiceAgent_role,
+    google_organization_iam_member.organization_xpn_role,
+    google_organization_iam_member.orgPolicyAdmin_role,
+    google_organization_iam_member.policyAdmin_role,
+    google_service_account_iam_member.service_account_token_creator,
+    google_service_account_iam_member.service_account_user,
+    google_billing_account_iam_member.tf_billing_admin,
+    google_project_iam_member.cb_service_agent_role,
+    google_project_iam_member.google_services_usage_consumer,
+    google_project_iam_member.compute_engine_service_agent_role,
+    google_project_iam_member.compute_engine_default_service_agent_role,
+  ]
+}
+
 resource "google_service_account_key" "int_test" {
   service_account_id = google_service_account.int_test.id
+  depends_on         = [time_sleep.wait_iam_propagation]
 }
 
 resource "google_service_account_iam_member" "service_account_token_creator" {
@@ -130,12 +152,6 @@ resource "google_project_iam_member" "google_services_usage_consumer" {
 }
 
 resource "google_project_iam_member" "compute_engine_service_agent_role" {
-  project = module.seed_project.project_id
-  role    = "roles/serviceusage.serviceUsageConsumer"
-  member  = "serviceAccount:service-${module.seed_project.project_number}@compute-system.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_member" "compute_engine_service_usage_role" {
   project = module.seed_project.project_id
   role    = "roles/serviceusage.serviceUsageConsumer"
   member  = "serviceAccount:service-${module.seed_project.project_number}@compute-system.iam.gserviceaccount.com"

--- a/test/setup/modules/private_workerpool/main.tf
+++ b/test/setup/modules/private_workerpool/main.tf
@@ -79,6 +79,12 @@ resource "google_project_service" "servicenetworking" {
   disable_on_destroy = false
 }
 
+resource "time_sleep" "wait_service_network_peering" {
+  depends_on = [google_service_networking_connection.gitlab_worker_pool_conn]
+
+  create_duration = "60s"
+}
+
 resource "google_cloudbuild_worker_pool" "pool" {
   name     = "cb-pool"
   project  = module.private_workerpool_project.project_id
@@ -93,11 +99,5 @@ resource "google_cloudbuild_worker_pool" "pool" {
     peered_network_ip_range = "/24"
   }
 
-  depends_on = [google_service_networking_connection.gitlab_worker_pool_conn, module.private_workerpool_project]
-}
-
-resource "time_sleep" "wait_service_network_peering" {
-  depends_on = [google_service_networking_connection.gitlab_worker_pool_conn]
-
-  create_duration = "30s"
+  depends_on = [time_sleep.wait_service_network_peering, module.private_workerpool_project]
 }

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -15,28 +15,34 @@
  */
 
 output "seed_project_id" {
-  value = module.seed_project.project_id
+  value      = module.seed_project.project_id
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "seed_project_number" {
-  value = module.seed_project.project_number
+  value      = module.seed_project.project_number
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "seed_folder_id" {
-  value = module.folder_seed.id
+  value      = module.folder_seed.id
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "sa_email" {
-  value = google_service_account.int_test.email
+  value      = google_service_account.int_test.email
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "sa_id" {
-  value = google_service_account.int_test.id
+  value      = google_service_account.int_test.id
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "sa_key" {
-  value     = google_service_account_key.int_test.private_key
-  sensitive = true
+  value      = google_service_account_key.int_test.private_key
+  sensitive  = true
+  depends_on = [time_sleep.wait_iam_propagation]
 }
 
 output "cloud_build_sa" {


### PR DESCRIPTION
- Add explicit time_sleep resources and DAG dependencies for IAM role bindings across root test setup and harnesses
- Eliminate duplicate IAM role assignment causing 409 concurrent policy modification conflicts
- Wire time_sleep.wait_propagation into deployment pipeline modules and examples
- Fix build directory path and add IAM propagation delay for binary authorization image creation
- Fix service network peering sleep dependency in private workerpool harness
- Expand retryable transient error patterns in testutils for IAM, rate limits, and network errors
- Harden integration test polling loops to tolerate transient container startup and kubectl connection errors