### PR TITLE
feat: adds ncc on single project examples

### DIFF
--- a/examples/agent/standalone-single-project/vpc-sc-policies.tf
+++ b/examples/agent/standalone-single-project/vpc-sc-policies.tf
@@ -27,12 +27,12 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
   count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "e-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {
@@ -49,12 +49,12 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
   count = var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "e-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {

--- a/examples/agent/standalone-single-project/vpc-sc-policies.tf
+++ b/examples/agent/standalone-single-project/vpc-sc-policies.tf
@@ -24,7 +24,7 @@ data "google_project" "workerpool_network_project" {
 ###############################################
 
 resource "google_access_context_manager_service_perimeter_egress_policy" "egress_policy" {
-  count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null ? 1 : 0
+  count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
   title     = "e-projects/${local.secret_project_number}"
@@ -46,7 +46,7 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
 }
 
 resource "google_access_context_manager_service_perimeter_dry_run_egress_policy" "egress_policy" {
-  count = var.service_perimeter_name != null ? 1 : 0
+  count = var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
   title     = "e-projects/${local.secret_project_number}"

--- a/examples/default-example/standalone-single-project/vpc-sc-policies.tf
+++ b/examples/default-example/standalone-single-project/vpc-sc-policies.tf
@@ -27,12 +27,12 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
   count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "de-e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "de-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {
@@ -49,12 +49,12 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
   count = var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "de-e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "de-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {

--- a/examples/default-example/standalone-single-project/vpc-sc-policies.tf
+++ b/examples/default-example/standalone-single-project/vpc-sc-policies.tf
@@ -24,7 +24,7 @@ data "google_project" "workerpool_network_project" {
 ###############################################
 
 resource "google_access_context_manager_service_perimeter_egress_policy" "egress_policy" {
-  count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null ? 1 : 0
+  count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
   title     = "de-e-projects/${local.secret_project_number}"
@@ -46,7 +46,7 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
 }
 
 resource "google_access_context_manager_service_perimeter_dry_run_egress_policy" "egress_policy" {
-  count = var.service_perimeter_name != null ? 1 : 0
+  count = var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
   title     = "de-e-projects/${local.secret_project_number}"

--- a/examples/llm-model/standalone-single-project/vpc-sc-policies.tf
+++ b/examples/llm-model/standalone-single-project/vpc-sc-policies.tf
@@ -27,12 +27,12 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
   count = var.service_perimeter_mode == "ENFORCE" && var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "llm-model-e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "llm-model-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {
@@ -49,12 +49,12 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
   count = var.service_perimeter_name != null && local.secret_project_number != null ? 1 : 0
 
   perimeter = var.service_perimeter_name
-  title     = "llm-model-e-projects/${local.secret_project_number}"
+  title     = local.secret_project_number != null ? "llm-model-projects/${local.secret_project_number}" : null
   egress_from {
     identities = ["serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com"]
   }
   egress_to {
-    resources = ["projects/${local.secret_project_number}"]
+    resources = local.secret_project_number != null ? ["projects/${local.secret_project_number}"] : null
     operations {
       service_name = "secretmanager.googleapis.com"
       method_selectors {

--- a/test/integration/agent/standalone_single_project_test.go
+++ b/test/integration/agent/standalone_single_project_test.go
@@ -60,6 +60,14 @@ func TestStandaloneSingleProjectAgentExample(t *testing.T) {
 		t.Fatalf("failed to set GOOGLE_IMPERSONATE_SERVICE_ACCOUNT: %v", err)
 	}
 
+	ncc_config := map[string]interface{}{
+		"enable_ncc":        true,
+		"hub_uri":           setupOutput.GetStringOutput("ncc_hub_uri"),
+		"spoke_group":       setupOutput.GetStringOutput("ncc_group"),
+		"spoke_name":        "vpc-spoke-agent",
+		"spoke_description": "Spoke for agent single project example",
+	}
+
 	vars := map[string]interface{}{
 		"project_id":             projectID,
 		"service_perimeter_mode": service_perimeter_mode,
@@ -72,6 +80,7 @@ func TestStandaloneSingleProjectAgentExample(t *testing.T) {
 		"network_id":             gitLab.GetStringOutput("network_id"),
 		"create_nat":             false,
 		"enables_network_connection_and_peering_routes": false,
+		"ncc_config": ncc_config,
 	}
 
 	// wire setup output project_id to example var.project_id

--- a/test/integration/default-example/standalone_single_project_test.go
+++ b/test/integration/default-example/standalone_single_project_test.go
@@ -58,8 +58,8 @@ func TestStandaloneSingleProjectDefaultExample(t *testing.T) {
 	}
 	ncc_config := map[string]interface{}{
 		"enable_ncc":        true,
-		"hub_uri":           loggingBucket.GetTFSetupStringOutput("ncc_hub_uri"),
-		"spoke_group":       loggingBucket.GetTFSetupStringOutput("ncc_group"),
+		"hub_uri":           setupVPCSCOutput.GetTFSetupStringOutput("ncc_hub_uri"),
+		"spoke_group":       setupVPCSCOutput.GetTFSetupStringOutput("ncc_group"),
 		"spoke_name":        "vpc-spoke-agent",
 		"spoke_description": "Spoke for agent single project example",
 	}

--- a/test/integration/default-example/standalone_single_project_test.go
+++ b/test/integration/default-example/standalone_single_project_test.go
@@ -56,6 +56,13 @@ func TestStandaloneSingleProjectDefaultExample(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set GOOGLE_IMPERSONATE_SERVICE_ACCOUNT: %v", err)
 	}
+	ncc_config := map[string]interface{}{
+		"enable_ncc":        true,
+		"hub_uri":           loggingBucket.GetTFSetupStringOutput("ncc_hub_uri"),
+		"spoke_group":       loggingBucket.GetTFSetupStringOutput("ncc_group"),
+		"spoke_name":        "vpc-spoke-agent",
+		"spoke_description": "Spoke for agent single project example",
+	}
 
 	vars := map[string]interface{}{
 		"project_id":             projectID,
@@ -68,6 +75,7 @@ func TestStandaloneSingleProjectDefaultExample(t *testing.T) {
 		"network_id":             gitLab.GetStringOutput("network_id"),
 		"create_nat":             false,
 		"enables_network_connection_and_peering_routes": false,
+		"ncc_config": ncc_config,
 	}
 
 	// wire setup output project_id to example var.project_id

--- a/test/integration/default-example/standalone_single_project_test.go
+++ b/test/integration/default-example/standalone_single_project_test.go
@@ -60,8 +60,8 @@ func TestStandaloneSingleProjectDefaultExample(t *testing.T) {
 		"enable_ncc":        true,
 		"hub_uri":           setupVPCSCOutput.GetTFSetupStringOutput("ncc_hub_uri"),
 		"spoke_group":       setupVPCSCOutput.GetTFSetupStringOutput("ncc_group"),
-		"spoke_name":        "vpc-spoke-agent",
-		"spoke_description": "Spoke for agent single project example",
+		"spoke_name":        "vpc-spoke-default",
+		"spoke_description": "Spoke for default example single project example",
 	}
 
 	vars := map[string]interface{}{

--- a/test/integration/llm-model/standalone_single_project_test.go
+++ b/test/integration/llm-model/standalone_single_project_test.go
@@ -60,7 +60,13 @@ func TestStandaloneSingleProjectLLMModel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to set GOOGLE_IMPERSONATE_SERVICE_ACCOUNT: %v", err)
 	}
-
+	ncc_config := map[string]interface{}{
+		"enable_ncc":        true,
+		"hub_uri":           setupOutput.GetStringOutput("ncc_hub_uri"),
+		"spoke_group":       setupOutput.GetStringOutput("ncc_group"),
+		"spoke_name":        "vpc-spoke-agent",
+		"spoke_description": "Spoke for agent single project example",
+	}
 	vars := map[string]interface{}{
 		"project_id":             projectID,
 		"service_perimeter_mode": service_perimeter_mode,
@@ -73,6 +79,7 @@ func TestStandaloneSingleProjectLLMModel(t *testing.T) {
 		"network_id":             gitLab.GetStringOutput("network_id"),
 		"create_nat":             false,
 		"enables_network_connection_and_peering_routes": false,
+		"ncc_config": ncc_config,
 	}
 
 	// wire setup output project_id to example var.project_id

--- a/test/integration/llm-model/standalone_single_project_test.go
+++ b/test/integration/llm-model/standalone_single_project_test.go
@@ -64,8 +64,8 @@ func TestStandaloneSingleProjectLLMModel(t *testing.T) {
 		"enable_ncc":        true,
 		"hub_uri":           setupOutput.GetStringOutput("ncc_hub_uri"),
 		"spoke_group":       setupOutput.GetStringOutput("ncc_group"),
-		"spoke_name":        "vpc-spoke-agent",
-		"spoke_description": "Spoke for agent single project example",
+		"spoke_name":        "vpc-spoke-llm-model",
+		"spoke_description": "Spoke for llm model single project example",
 	}
 	vars := map[string]interface{}{
 		"project_id":             projectID,

--- a/test/setup/README.md
+++ b/test/setup/README.md
@@ -24,22 +24,21 @@ The Setup module creates the required prerequisite resources to deploy the bluep
 
 | Name | Description |
 |------|-------------|
-| billing\_account | n/a |
-| cloud\_build\_sa | n/a |
-| harness\_project\_ids | n/a |
-| harness\_project\_numbers | n/a |
-| hpc | n/a |
-| hub\_network | n/a |
-| ncc\_group | n/a |
-| ncc\_hub\_uri | n/a |
-| org\_id | n/a |
-| sa\_email | n/a |
-| sa\_id | n/a |
-| sa\_key | n/a |
-| seed\_folder\_id | n/a |
-| seed\_project\_id | n/a |
-| seed\_project\_number | n/a |
-| single\_project | n/a |
-| teams | n/a |
+| billing\_account | Billing account used to be linked at projects. |
+| cloud\_build\_sa | The cloud build service account (when using Cloud build). |
+| harness\_project\_ids | A list of the projects ids created including seed. |
+| harness\_project\_numbers | A list of the projects numbers created including seed. |
+| hpc | If is a HPC example being deployed. |
+| ncc\_group | The NCC group name. |
+| ncc\_hub\_uri | NCC Hub id. |
+| org\_id | Organization ID used to create projects. |
+| sa\_email | All service accounts email created for examples, including in seed project. |
+| sa\_id | All service accounts id created for examples, including in seed project. |
+| sa\_key | The seed private key. |
+| seed\_folder\_id | Seed folder id. |
+| seed\_project\_id | Seed project id. |
+| seed\_project\_number | Seed project number. |
+| single\_project | If single project examples are being deployed. |
+| teams | Workspace groups id. |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/test/setup/hub_network.tf
+++ b/test/setup/hub_network.tf
@@ -44,7 +44,7 @@ module "hub_network" {
 
 module "network_connectivity_center_star" {
   source  = "terraform-google-modules/network/google//modules/network-connectivity-center"
-  version = "~> 18.0"
+  version = "~> 18.1"
 
   project_id   = module.seed_project.project_id
   ncc_hub_name = "eab-hub-star"

--- a/test/setup/outputs.tf
+++ b/test/setup/outputs.tf
@@ -15,70 +15,82 @@
  */
 
 output "harness_project_ids" {
-  value = merge({ for i, v in module.harness_project : (i) => v.project_id }, { "seed" : module.seed_project.project_id })
+  description = "A list of the projects ids created including seed."
+  value       = merge({ for i, v in module.harness_project : (i) => v.project_id }, { "seed" : module.seed_project.project_id })
 }
 
 output "harness_project_numbers" {
-  value = merge({ for i, v in module.harness_project : (i) => v.project_number }, { "seed" : module.seed_project.project_number })
+  description = "A list of the projects numbers created including seed."
+  value       = merge({ for i, v in module.harness_project : (i) => v.project_number }, { "seed" : module.seed_project.project_number })
 }
 
 output "seed_project_number" {
-  value = module.seed_project.project_number
+  description = "Seed project number."
+  value       = module.seed_project.project_number
 }
 
 output "seed_project_id" {
-  value = module.seed_project.project_id
-}
-
-output "hub_network" {
-  value = module.hub_network.network
+  description = "Seed project id."
+  value       = module.seed_project.project_id
 }
 
 output "ncc_group" {
-  value = "edge"
+  description = "The NCC group name."
+  value       = "edge"
 }
 
 output "ncc_hub_uri" {
-  value = module.network_connectivity_center_star.ncc_hub.id
+  description = "NCC Hub id."
+  value       = module.network_connectivity_center_star.ncc_hub.id
 }
 
 output "seed_folder_id" {
-  value = module.folder_seed.id
+  description = "Seed folder id."
+  value       = module.folder_seed.id
 }
 
 output "sa_email" {
-  value = { for i, v in google_service_account.int_test : (i) => v.email }
+  description = "All service accounts email created for examples, including in seed project."
+  value       = { for i, v in google_service_account.int_test : (i) => v.email }
 }
 
 output "sa_id" {
-  value = { for i, v in google_service_account.int_test : (i) => v.id }
+  description = "All service accounts id created for examples, including in seed project."
+  value       = { for i, v in google_service_account.int_test : (i) => v.id }
 }
 
 output "sa_key" {
-  value     = google_service_account_key.int_test["seed"].private_key
-  sensitive = true
+  description = "The seed private key."
+  value       = google_service_account_key.int_test["seed"].private_key
+  sensitive   = true
 }
 
 output "cloud_build_sa" {
-  value = var.cloud_build_sa
+  description = "The cloud build service account (when using Cloud build)."
+  value       = var.cloud_build_sa
 }
 
 output "billing_account" {
-  value = var.billing_account
+  description = "Billing account used to be linked at projects."
+  value       = var.billing_account
 }
 
 output "org_id" {
-  value = var.org_id
+  description = "Organization ID used to create projects."
+  value       = var.org_id
 }
 
 output "teams" {
-  value = { for team, group in module.group : team => module.group[team].id }
+  description = "Workspace groups id."
+  value       = { for team, group in module.group : team => module.group[team].id }
 }
 
 output "single_project" {
-  value = var.single_project
+  description = "If single project examples are being deployed."
+  value       = var.single_project
 }
 
 output "hpc" {
-  value = var.hpc
+  description = "If is a HPC example being deployed."
+  value       = var.hpc
 }


### PR DESCRIPTION
Enables NCC usage on Single project examples:
- Default example
- LLM Model
- Capital Agent

cluster-multicluster-discovery example will remain with NCC disabled for testing on purpose.

Also, fix directional rule for default and agent example: if secret project is null, directional rule is not created.