### PR TITLE
chore: enable ADC for connect gateway and bump dev-tools to 1.28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.25
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 1.28
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/build/int.cloudbuild.agent.yaml
+++ b/build/int.cloudbuild.agent.yaml
@@ -27,7 +27,7 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"
 options:
   machineType: E2_HIGHCPU_32
   env:
@@ -44,3 +44,4 @@ options:
     - "TF_VAR_region=us-central1"
     - "TF_VAR_location=us-central1"
     - "_SKIP_GITLAB=false"
+    - "CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true"

--- a/build/int.cloudbuild.hpc.yaml
+++ b/build/int.cloudbuild.hpc.yaml
@@ -27,4 +27,4 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"

--- a/build/int.cloudbuild.htc.yaml
+++ b/build/int.cloudbuild.htc.yaml
@@ -27,4 +27,4 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"

--- a/build/int.cloudbuild.singleproject.confidentialnodes.yaml
+++ b/build/int.cloudbuild.singleproject.confidentialnodes.yaml
@@ -27,4 +27,4 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"

--- a/build/int.cloudbuild.singleproject.yaml
+++ b/build/int.cloudbuild.singleproject.yaml
@@ -280,7 +280,7 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"
 options:
   machineType: E2_HIGHCPU_32
   env:
@@ -298,3 +298,4 @@ options:
     - "TF_VAR_location=us-central1"
     - "_SKIP_GITLAB=false"
     - 'TF_VAR_examples_tested=["llm-model","agent","default-example"]'
+    - "CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -131,7 +131,7 @@ tags:
   - "integration"
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: "cft/developer-tools"
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.25"
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: "1.28"
 options:
   machineType: E2_HIGHCPU_32
   env:
@@ -145,3 +145,4 @@ options:
     - "TF_VAR_agent=false"
     - "HEAD_BRANCH=$_HEAD_BRANCH"
     - "HEAD_REPO_URL=$_HEAD_REPO_URL"
+    - "CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true"

--- a/test/integration/testutils/utils.go
+++ b/test/integration/testutils/utils.go
@@ -33,6 +33,12 @@ const (
 	credsMutexFilename = "creds.lock"
 )
 
+func init() {
+	if err := os.Setenv("CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS", "true"); err != nil {
+		panic(fmt.Sprintf("failed to set CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS: %v", err))
+	}
+}
+
 // fileExists check if a give file exists
 func FileExists(filePath string) (bool, error) {
 	_, err := os.Stat(filePath)


### PR DESCRIPTION
- Configure Connect Gateway to use native Application Default Credentials (ADC) in testutils.ConnectToFleet and Cloud Build options.env. This prevents gke-gcloud-auth-plugin from invoking 'gcloud config config-helper', which crashes on Google Cloud SDK >= 573.0.0 due to upstream bug b/525047270.
- Bump cft/developer-tools to 1.28 across build configurations and Makefile.